### PR TITLE
Added new function collidePointEllipse

### DIFF
--- a/p5.collide2d.js
+++ b/p5.collide2d.js
@@ -65,6 +65,19 @@ if( this.dist(x,y,cx,cy) <= d/2 ){
 return false;
 };
 
+p5.prototype.collidePointEllipse = function (x, y, cx, cy, dx, dy) {
+  //2d
+  var rx = dx/2, ry = dy/2;
+  // Discarding the points outside the bounding box
+  if (x > cx + rx || x < cx - rx ||y > cy + ry || y < cy - ry) {
+		return false;
+  } 
+  // Compare the point to its equivalent on the ellipse
+  var xx = x - cx, yy = y - cy;
+  var eyy = ry * this.sqrt(this.abs(rx * rx - xx * xx)) / rx;
+  return yy <= eyy && yy >= -eyy;
+};
+
 p5.prototype.collidePointRect = function (pointX, pointY, x, y, xW, yW) {
 //2d
 if (pointX >= x &&         // right of the left edge AND


### PR DESCRIPTION
Added a more generic function for elliptical shapes. The function takes the point, the centre of the ellipse, the major and the minor axes (diameters).
We firstly discard all the points outside the bounding box (rectangle surrounding the shape) to avoid overusing the square root function.
Example image:
![collidepointellipse_test](https://user-images.githubusercontent.com/13430702/47784680-98543d80-dd06-11e8-8814-47a37186263a.png)
